### PR TITLE
Make frontend CORS origin configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+FRONTEND_ORIGIN=http://127.0.0.1:8000
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/app/Http/Middleware/Cors.php
+++ b/app/Http/Middleware/Cors.php
@@ -8,7 +8,11 @@ class Cors
     public function handle($request, Closure $next)
     {
         $response = $next($request);
-        $response->header('Access-Control-Allow-Origin', 'https://home.kilauindonesia.org');
+        $origin = config('app.frontend_origin', '*');
+
+        if (! empty($origin)) {
+            $response->header('Access-Control-Allow-Origin', $origin);
+        }
         $response->header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, DELETE, PUT');
         $response->header('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
         $response->header('Access-Control-Allow-Credentials', 'true');

--- a/config/app.php
+++ b/config/app.php
@@ -58,6 +58,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Frontend Origin
+    |--------------------------------------------------------------------------
+    |
+    | This value determines which origin is allowed to access the API when
+    | handling cross-origin requests. Set this value in your ".env" file.
+    |
+    */
+
+    'frontend_origin' => env('FRONTEND_ORIGIN', 'https://home.kilauindonesia.org'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Timezone
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## Summary
- read the Access-Control-Allow-Origin header value from a configurable frontend_origin option
- add a new configuration entry that sources the allowed origin from the FRONTEND_ORIGIN environment variable
- document the new environment variable in the example .env file

## Testing
- `php artisan config:clear` *(fails: vendor autoloader not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d65438b5788323bcc54a8977f7c0c5