### PR TITLE
Use environment variable for Kilau API base URI

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -31,7 +31,7 @@ return [
     ],
     
     'kilau_api' => [
-        'base_uri' => 'https://kilauindonesia.org/kilau/api/',
+        'base_uri' => env('KILAU_API_BASE_URI', 'https://kilauindonesia.org/kilau/api/'),
         'timeout' => 5, // Waktu timeout dalam detik
     ],
 


### PR DESCRIPTION
## Summary
- update the Kilau API service configuration to read the base URI from the KILAU_API_BASE_URI environment variable while keeping the existing production URL as the default

## Testing
- php artisan config:clear *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6554e30588323bc3a1e292ae857a0